### PR TITLE
feat(xslt): handle `hi rend="#i"` and `hi rend="#letterspaced"` in al…

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -57,3 +57,11 @@ div#map {
 #main {
     scroll-margin-top: 1rem;
 }
+
+/* Implement MRP rendition specifications */
+.italic {
+    font-style:italic;
+}
+.letterspaced {
+    letter-spacing:0.15em;
+}

--- a/xslt/partials/shared.xsl
+++ b/xslt/partials/shared.xsl
@@ -98,7 +98,8 @@
                         <xsl:text>italic</xsl:text>
                     </xsl:attribute>
                 </xsl:when>
-                <xsl:when test="@rendition = '#italic'">
+                <!-- <xsl:when test="@rendition = '#italic'"> -->
+                <xsl:when test="@rendition = '#italic' or @rend = '#i'"><!-- CHANGE: align with MRP rendition specifications -->
                     <xsl:attribute name="class">
                         <xsl:text>italic</xsl:text>
                     </xsl:attribute>
@@ -111,6 +112,12 @@
                 <xsl:when test="@rendition = '#bold'">
                     <xsl:attribute name="class">
                         <xsl:text>bold</xsl:text>
+                    </xsl:attribute>
+                </xsl:when>
+                <!-- CHANGE: align with MRP rendition specifications -->
+                <xsl:when test="@rend = '#letterspaced'">
+                    <xsl:attribute name="class">
+                        <xsl:text>letterspaced</xsl:text>
                     </xsl:attribute>
                 </xsl:when>
             </xsl:choose>


### PR DESCRIPTION
…ignment with MRP rendition specs (#74)